### PR TITLE
[#14] Feat: Header 구현

### DIFF
--- a/src/Components/Header/Header.tsx
+++ b/src/Components/Header/Header.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import styled from 'styled-components';
+
+const Header: React.FC = () => {
+  return (
+    <>
+      <HeaderLayout>
+        <HeaderTitleLayout>TO DO LIST</HeaderTitleLayout>
+        <FilterIconLayout>filter icon</FilterIconLayout>
+      </HeaderLayout>
+    </>
+  );
+};
+
+const HeaderLayout = styled.div`
+  position: sticky;
+  display: flex;
+  justify-content: center;
+
+  padding: 1rem;
+
+  border-bottom: 1px solid #999999;
+  box-shadow: 0 0 50px 0 rgba(0, 0, 0, 0.1);
+`;
+
+const HeaderTitleLayout = styled.div`
+  width: 95%;
+
+  padding: 1rem;
+
+  text-align: center;
+  color: #555555;
+  font-size: 2.5rem;
+`;
+
+const FilterIconLayout = styled.div`
+  width: 5%;
+  border: 1px solid black;
+
+  text-align: center;
+`;
+
+export default Header;

--- a/src/Components/Header/index.ts
+++ b/src/Components/Header/index.ts
@@ -1,0 +1,2 @@
+import Header from './Header';
+export default Header;

--- a/src/Pages/TodoList/TodoList.tsx
+++ b/src/Pages/TodoList/TodoList.tsx
@@ -1,44 +1,64 @@
 import React from 'react';
 import styled from 'styled-components';
 
+import Header from 'Components/Header';
+
 const TodoList: React.FC = () => {
   return (
-    <ul style={{ padding: '20px' }}>
-      <Li>
-        <span style={{ fontSize: '20px' }}>코드리뷰하기1</span>
-        <div style={{ display: 'flex', alignItems: 'center' }}>
-          <button>icon</button>
-          <div>selectBox</div>
-          <button>휴지통</button>
-        </div>
-      </Li>
-      <Li>
-        <span style={{ fontSize: '20px' }}>컴포넌트설계2</span>
-        <div style={{ display: 'flex' }}>
-          <button>icon</button>
-          <div>selectBox</div>
-          <button>휴지통</button>
-        </div>
-      </Li>
-      <Li>
-        <span style={{ fontSize: '20px' }}>밥먹기3</span>
-        <div style={{ display: 'flex' }}>
-          <button>icon</button>
-          <div>selectBox</div>
-          <button>휴지통</button>
-        </div>
-      </Li>
-      <Li>
-        <span style={{ fontSize: '20px' }}>코딩하기4</span>
-        <div style={{ display: 'flex' }}>
-          <button>icon</button>
-          <div>selectBox</div>
-          <button>휴지통</button>
-        </div>
-      </Li>
-    </ul>
+    <TodoListTemplate>
+      <Header />
+
+      <TodoItemsLayout>
+        <ul style={{ padding: '20px' }}>
+          <Li>
+            <span style={{ fontSize: '20px' }}>코드리뷰하기</span>
+            <div style={{ display: 'flex', alignItems: 'center' }}>
+              <button>icon</button>
+              <div>selectBox</div>
+              <button>휴지통</button>
+            </div>
+          </Li>
+          <Li>
+            <span style={{ fontSize: '20px' }}>컴포넌트설계2</span>
+            <div style={{ display: 'flex' }}>
+              <button>icon</button>
+              <div>selectBox</div>
+              <button>휴지통</button>
+            </div>
+          </Li>
+          <Li>
+            <span style={{ fontSize: '20px' }}>밥먹기3</span>
+            <div style={{ display: 'flex' }}>
+              <button>icon</button>
+              <div>selectBox</div>
+              <button>휴지통</button>
+            </div>
+          </Li>
+          <Li>
+            <span style={{ fontSize: '20px' }}>코딩하기4</span>
+            <div style={{ display: 'flex' }}>
+              <button>icon</button>
+              <div>selectBox</div>
+              <button>휴지통</button>
+            </div>
+          </Li>
+        </ul>
+      </TodoItemsLayout>
+    </TodoListTemplate>
   );
 };
+
+const TodoListTemplate = styled.div`
+  background: white;
+
+  display: flex;
+  flex-direction: column;
+`;
+
+const TodoItemsLayout = styled.div`
+  overflow-y: scroll;
+  margin: 2rem;
+`;
 
 const Li = styled.li`
   padding: 10px 0;


### PR DESCRIPTION

# PR 제목
[#14] Feat: Header 구현

- TodoList 레이아웃 설정
- 임시 스타일링 적용

<br/>

## 해당 이슈 📎
- Close #14 
<br/>

## 변경 사항 🛠
- 추후에 스타일 관련 코드는 별도의 파일로 분리할 예정입니다.
- 헤더의 레이아웃을 잡기 위해서 임시로 TodoList 컴포넌트에도 레이아웃에 스타일을 약간 적용했습니다. 
 현재는 아래 스샷같은 모습(맥북 13인치 기준)인데 스타일링은 나중에 변경하면 될 것 같습니다 :)
![image](https://user-images.githubusercontent.com/65105537/130662834-e2dbb972-d409-4137-a6b8-5f0b07b614db.png)
<br/>

## 리뷰어 참고 사항 🙋‍♀️
구현을 하다보니 몇 가지 의논했으면 하는 점이 생겼습니다: 
1. 헤더에 필터링 아이콘을 적용하려다 보니 icon을 관리하는 폴더도 필요할 것 같아 폴더만 추가해 둔 상태입니다 (아직 파일이 없어 깃에는 올라갈 것 같지는 않습니다). 폴더 위치가 적절한걸까요? 🤔
![image](https://user-images.githubusercontent.com/65105537/130663820-09d3aa49-527a-4060-be3d-9576f46071e6.png)
2. Header에 타이틀만 넣으려니 약간 밋밋한 감이 있는 것 같기도 해서.. 지난번 투두과제처럼 현재 날짜를 타이틀 대신에 띄워주면 UX측면에서 낫지 않을까 하는 생각이 드는데 어떠신가요?
3. 아직 사용할 Icon 라이브러리가 정해지지 않아서 <a href="https://react-icons.github.io/react-icons/" target="_blank">React Icons</a>나 <a href="https://fontawesome.com/" target="_blank">Font Awesome</a> 중에 사용하면 어떨지 고려하고 있는데 어떤 걸 사용하는 게 좋을지 의논이 필요할 것 같습니다! 찾아보니 둘 다 사용하게 되면 `npm install`은 해야할 것 같네요.
<br/>
