### PR TITLE
[#59] Refactor : filter 기능 로직 수정

### DIFF
--- a/src/Hooks/useFilter.tsx
+++ b/src/Hooks/useFilter.tsx
@@ -1,5 +1,5 @@
+/* eslint-disable @typescript-eslint/explicit-module-boundary-types */
 import React, { useState } from 'react';
-import { useEffect } from 'react';
 import { Itodo, Sort, Tfilter } from 'types';
 import { TodoDate } from 'utils/todoDate';
 
@@ -11,12 +11,6 @@ const initialFilter: Tfilter = {
 const useFilter = () => {
   const date = new TodoDate();
   const [filter, setFilter] = useState<Tfilter>(initialFilter);
-  const [initialTodo, setInitialTodo] = useState<Itodo[] | null>(null);
-  const [isFirst, setIsFirst] = useState(true);
-
-  useEffect(() => {
-    if (initialTodo !== null) setIsFirst(false);
-  }, [initialTodo]);
 
   const sortByDuedate = (todos: Itodo[]): Itodo[] => {
     const newTodos = JSON.parse(JSON.stringify(todos)) as Itodo[];
@@ -32,14 +26,11 @@ const useFilter = () => {
   };
 
   const applyFilter = (todos: Itodo[], filter: Tfilter): Itodo[] => {
-    if (initialTodo === null) setInitialTodo(todos);
-
     let data: Itodo[] | null = null;
-
     if (filter.sort === Sort.DUE_DATE) data = sortByDuedate(todos);
-    else if (!isFirst && filter.sort === Sort.BASIC) data = todos;
+    else data = todos;
 
-    return filterByProgress(data || (initialTodo as Itodo[]), filter);
+    return filterByProgress(data, filter);
   };
 
   return { filter, setFilter, applyFilter };


### PR DESCRIPTION
# PR 제목
[#59] Refactor : filter 기능 로직 수정

## 해당 이슈 📎
- close #59 
<br/>

## 변경 사항 🛠

1. `initialTodo`가 삭제되었습니다. (첫 데이터 구분 로직)
2. `isFirst`가 삭제되었습니다. (첫 렌더링 구분 로직)

```ts
  const applyFilter = (todos: Itodo[], filter: Tfilter): Itodo[] => {
    let data: Itodo[] | null = null;
    if (filter.sort === Sort.DUE_DATE) data = sortByDuedate(todos);
    else data = todos;

    return filterByProgress(data, filter);
  };
```

저번 렌더링 관련 에러가 `깊은 복사` 이슈로 판명이 나서, 
그 전에 고쳤던 로직을 확인했어야 했는데 확인을 못했었네요! 
확인 후 리팩토링 진행했습니다.

<br/>

